### PR TITLE
Spike: remove support for builtin types

### DIFF
--- a/backend/experiments/BwdDangerServer/Builtin.fs
+++ b/backend/experiments/BwdDangerServer/Builtin.fs
@@ -8,10 +8,5 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
 let contents : Builtin.Contents =
-  Builtin.combine [ Libs.Experiments.contents ] fnRenames typeRenames
+  Builtin.combine [ Libs.Experiments.contents ] fnRenames

--- a/backend/experiments/BwdDangerServer/DangerExecution.fs
+++ b/backend/experiments/BwdDangerServer/DangerExecution.fs
@@ -20,7 +20,7 @@ module Interpreter = LibExecution.Interpreter
 open LibCloud
 
 let builtIns : RT.BuiltIns =
-  let (fns, types, constants) =
+  let (fns, constants) =
     LibExecution.Builtin.combine
       [ BuiltinExecution.Builtin.contents
           BuiltinExecution.Libs.HttpClient.defaultConfig
@@ -28,9 +28,7 @@ let builtIns : RT.BuiltIns =
         BwdDangerServer.Builtin.contents
         BuiltinDarkInternal.Builtin.contents ]
       []
-      []
-  { types = types |> Map.fromListBy (fun typ -> typ.name)
-    fns = fns |> Map.fromListBy (fun fn -> fn.name)
+  { fns = fns |> Map.fromListBy (fun fn -> fn.name)
     constants = constants |> Map.fromListBy (fun c -> c.name) }
 
 let packageManager = PackageManager.packageManager

--- a/backend/experiments/BwdDangerServer/Libs/Experiments.fs
+++ b/backend/experiments/BwdDangerServer/Libs/Experiments.fs
@@ -76,8 +76,8 @@ module RestrictedFileIO =
       None
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
+
 let fn = fn [ "Experiments" ]
 
 let fns : List<BuiltInFn> =
@@ -173,4 +173,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents : LibExecution.Builtin.Contents = (fns, types, constants)
+let contents : LibExecution.Builtin.Contents = (fns, constants)

--- a/backend/experiments/CanvasHack/Main.fs
+++ b/backend/experiments/CanvasHack/Main.fs
@@ -60,7 +60,6 @@ let seedCanvas (canvasName : string) =
             BwdDangerServer.Builtin.contents
             BuiltinDarkInternal.Builtin.contents ]
           []
-          []
       LibParser.NameResolver.fromBuiltins builtIns
       |> fun nr -> { nr with packageManager = Some packageManager }
 

--- a/backend/src/BuiltinCli/Builtin.fs
+++ b/backend/src/BuiltinCli/Builtin.fs
@@ -11,10 +11,6 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
 
 let contents =
   Builtin.combine
@@ -25,4 +21,3 @@ let contents =
       Libs.Output.contents
       Libs.Time.contents ]
     fnRenames
-    typeRenames

--- a/backend/src/BuiltinCli/Libs/Directory.fs
+++ b/backend/src/BuiltinCli/Libs/Directory.fs
@@ -11,7 +11,6 @@ module Dval = LibExecution.Dval
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Directory" ]
@@ -104,4 +103,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents : Builtin.Contents = (fns, types, constants)
+let contents : Builtin.Contents = (fns, constants)

--- a/backend/src/BuiltinCli/Libs/Environment.fs
+++ b/backend/src/BuiltinCli/Libs/Environment.fs
@@ -12,7 +12,6 @@ module Dval = LibExecution.Dval
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Environment" ]
@@ -64,4 +63,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents : Builtin.Contents = (fns, types, constants)
+let contents : Builtin.Contents = (fns, constants)

--- a/backend/src/BuiltinCli/Libs/File.fs
+++ b/backend/src/BuiltinCli/Libs/File.fs
@@ -11,7 +11,6 @@ module Dval = LibExecution.Dval
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "File" ]
@@ -204,4 +203,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents : Builtin.Contents = (fns, types, constants)
+let contents : Builtin.Contents = (fns, constants)

--- a/backend/src/BuiltinCli/Libs/Output.fs
+++ b/backend/src/BuiltinCli/Libs/Output.fs
@@ -10,7 +10,6 @@ open LibExecution.RuntimeTypes
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -50,4 +49,4 @@ let fns : List<BuiltInFn> =
     ]
 
 
-let contents : Builtin.Contents = (fns, types, constants)
+let contents : Builtin.Contents = (fns, constants)

--- a/backend/src/BuiltinCli/Libs/Process.fs
+++ b/backend/src/BuiltinCli/Libs/Process.fs
@@ -11,7 +11,7 @@ module Dval = LibExecution.Dval
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
   [ { name = fn [ "Process" ] "run" 0
@@ -56,5 +56,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let constants : List<BuiltInConstant> = []
-let contents : Builtin.Contents = (fns, types, constants)
+let contents : Builtin.Contents = (fns, constants)

--- a/backend/src/BuiltinCli/Libs/Time.fs
+++ b/backend/src/BuiltinCli/Libs/Time.fs
@@ -10,7 +10,6 @@ open LibExecution.RuntimeTypes
 module Builtin = LibExecution.Builtin
 open Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -33,4 +32,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents : Builtin.Contents = (fns, types, constants)
+let contents : Builtin.Contents = (fns, constants)

--- a/backend/src/BuiltinCliHost/Builtin.fs
+++ b/backend/src/BuiltinCliHost/Builtin.fs
@@ -11,9 +11,4 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
-let contents = Builtin.combine [ Libs.Cli.contents ] fnRenames typeRenames
+let contents = Builtin.combine [ Libs.Cli.contents ] fnRenames

--- a/backend/src/BuiltinCloudExecution/Builtin.fs
+++ b/backend/src/BuiltinCloudExecution/Builtin.fs
@@ -10,10 +10,4 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
-let contents =
-  Builtin.combine [ Libs.DB.contents; Libs.Event.contents ] fnRenames typeRenames
+let contents = Builtin.combine [ Libs.DB.contents; Libs.Event.contents ] fnRenames

--- a/backend/src/BuiltinCloudExecution/Libs/DB.fs
+++ b/backend/src/BuiltinCloudExecution/Libs/DB.fs
@@ -40,7 +40,6 @@ let handleUnexpectedExceptionDuringQuery
       e
     LibCloud.SqlCompiler.error "An error occurred while querying the Datastore"
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "DB" ]
@@ -444,4 +443,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinCloudExecution/Libs/Event.fs
+++ b/backend/src/BuiltinCloudExecution/Libs/Event.fs
@@ -12,7 +12,6 @@ open LibExecution.Builtin.Shortcuts
 
 let varA = TVariable "a"
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -39,4 +38,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Builtin.fs
+++ b/backend/src/BuiltinDarkInternal/Builtin.fs
@@ -16,11 +16,6 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
 // only accessible to the LibCloud.Config.allowedDarkInternalCanvasID canvas
 let internalFn (f : BuiltInFnSig) : BuiltInFnSig =
   (fun (state, typeArgs, args) ->
@@ -47,6 +42,5 @@ let contents =
       Libs.Users.contents
       Libs.Workers.contents ]
     fnRenames
-    typeRenames
-  |> (fun (fns, types, constants) ->
-    (fns |> List.map (fun f -> { f with fn = internalFn f.fn }), types, constants))
+  |> (fun (fns, constants) ->
+    (fns |> List.map (fun f -> { f with fn = internalFn f.fn }), constants))

--- a/backend/src/BuiltinDarkInternal/Libs/Canvases.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Canvases.fs
@@ -33,7 +33,6 @@ let packageCanvasType (addlModules : List<string>) (name : string) (version : in
   TypeName.fqPackage "Darklang" ("Internal" :: "Canvas" :: addlModules) name version
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -203,4 +202,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/DBs.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/DBs.fs
@@ -13,7 +13,6 @@ module UserDB = LibCloud.UserDB
 let fn = fn [ "DarkInternal"; "Canvas"; "DB" ]
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -52,4 +51,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/Documentation.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Documentation.fs
@@ -20,7 +20,6 @@ let packageDocType (addlModules : List<string>) (name : string) (version : int) 
     name
     version
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -67,4 +66,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/Domains.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Domains.fs
@@ -14,7 +14,6 @@ module Canvas = LibCloud.Canvas
 let fn = fn [ "DarkInternal"; "Canvas"; "Domain" ]
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -57,4 +56,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/F404s.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/F404s.fs
@@ -11,9 +11,9 @@ module Telemetry = LibService.Telemetry
 
 let fn = fn [ "DarkInternal"; "Canvas"; "F404" ]
 
-let types : List<BuiltInType> = []
 
 let constants : List<BuiltInConstant> = []
+
 let fns : List<BuiltInFn> = []
 // [ { name = fn "delete" 0
 //     typeParams = []
@@ -66,4 +66,4 @@ let fns : List<BuiltInFn> = []
 //     previewable = Impure
 //     deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/Infra.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Infra.fs
@@ -18,7 +18,7 @@ let packageInfraType (addlModules : List<string>) (name : string) (version : int
   TypeName.fqPackage "Darklang" ("Internal" :: "Infra" :: addlModules) name version
 
 
-let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
   [ { name = fn "log" 0
@@ -135,5 +135,4 @@ human-readable data."
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let constants : List<BuiltInConstant> = []
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/Secrets.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Secrets.fs
@@ -18,7 +18,6 @@ let packageSecretType (addlModules : List<string>) (name : string) (version : in
   TypeName.fqPackage "Darklang" ("Internal" :: "Canvas" :: addlModules) name version
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -97,4 +96,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/Users.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Users.fs
@@ -10,7 +10,6 @@ open LibExecution.Builtin.Shortcuts
 
 let fn = fn [ "DarkInternal"; "User" ]
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -31,4 +30,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinDarkInternal/Libs/Workers.fs
+++ b/backend/src/BuiltinDarkInternal/Libs/Workers.fs
@@ -59,7 +59,7 @@ let rulesToDval (rules : List<SchedulingRules.SchedulingRule.T>) : Dval =
   |> Dval.list (KTCustomType(typeName, []))
 
 
-let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
   [ { name = fn [ "DarkInternal"; "Canvas"; "Queue" ] "count" 0
@@ -143,5 +143,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let constants : List<BuiltInConstant> = []
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Builtin.fs
+++ b/backend/src/BuiltinExecution/Builtin.fs
@@ -10,11 +10,6 @@ let fnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
 let contents (httpConfig : Libs.HttpClient.Configuration) : Builtin.Contents =
   Builtin.combine
     [ Libs.Bool.contents
@@ -35,4 +30,3 @@ let contents (httpConfig : Libs.HttpClient.Configuration) : Builtin.Contents =
       Libs.String.contents
       Libs.X509.contents ]
     fnRenames
-    typeRenames

--- a/backend/src/BuiltinExecution/Libs/Base64.fs
+++ b/backend/src/BuiltinExecution/Libs/Base64.fs
@@ -12,7 +12,6 @@ module VT = ValueType
 module Dval = LibExecution.Dval
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let modules = [ "Base64" ]
@@ -100,4 +99,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Bool.fs
+++ b/backend/src/BuiltinExecution/Libs/Bool.fs
@@ -10,7 +10,6 @@ let fn = fn [ "Bool" ]
 
 let varA = TVariable "a"
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -30,4 +29,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Bytes.fs
+++ b/backend/src/BuiltinExecution/Libs/Bytes.fs
@@ -10,8 +10,6 @@ open LibExecution.Builtin.Shortcuts
 
 module Dval = LibExecution.Dval
 
-let types : List<BuiltInType> = []
-
 let modules = [ "Bytes" ]
 let fn = fn modules
 let constant = constant modules
@@ -105,4 +103,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Char.fs
+++ b/backend/src/BuiltinExecution/Libs/Char.fs
@@ -12,7 +12,6 @@ module VT = ValueType
 module Dval = LibExecution.Dval
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Char" ]
@@ -140,4 +139,4 @@ let fns : List<BuiltInFn> =
 
     ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Crypto.fs
+++ b/backend/src/BuiltinExecution/Libs/Crypto.fs
@@ -13,7 +13,6 @@ open Prelude
 open LibExecution.RuntimeTypes
 open LibExecution.Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Crypto" ]
@@ -97,4 +96,4 @@ let fns : List<BuiltInFn> =
       previewable = ImpurePreviewable
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/DateTime.fs
+++ b/backend/src/BuiltinExecution/Libs/DateTime.fs
@@ -25,7 +25,6 @@ let ISO8601DateParser (s : string) : Result<DarkDateTime.T, unit> =
     Ok(DarkDateTime.fromDateTime (result.ToUniversalTime()))
   | _ -> Error()
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "DateTime" ]
@@ -399,4 +398,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Dict.fs
+++ b/backend/src/BuiltinExecution/Libs/Dict.fs
@@ -19,8 +19,6 @@ let modules = [ "Dict" ]
 let fn = fn modules
 let constant = constant modules
 
-let types : List<BuiltInType> = []
-
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -432,4 +430,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Float.fs
+++ b/backend/src/BuiltinExecution/Libs/Float.fs
@@ -9,7 +9,6 @@ open LibExecution.Builtin.Shortcuts
 module VT = ValueType
 module Dval = LibExecution.Dval
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Float" ]
@@ -328,4 +327,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -517,14 +517,14 @@ let fns (config : Configuration) : List<BuiltInFn> =
 
               | Error(err) ->
                 let! err = err |> RequestError.toDT
-                return! (err |> resultError)
+                return (err |> resultError)
 
             }
 
           | Error reqHeadersErr, _ ->
             uply {
               let! reqHeadersErr = reqHeadersErr |> HeaderError.toDT
-              return! reqHeadersErr |> resultError
+              return reqHeadersErr |> resultError
             }
 
           | _, None ->

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -384,7 +384,7 @@ let headersType = TList(TTuple(TString, TString, []))
 
 open LibExecution.Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
 
 let fns (config : Configuration) : List<BuiltInFn> =
   let httpClient = BaseClient.create config
@@ -423,7 +423,14 @@ let fns (config : Configuration) : List<BuiltInFn> =
         received and parsed, and is wrapped in {{ Error }} otherwise"
       fn =
         let responseType =
-          KTCustomType(FQName.BuiltIn(typ [ "HttpClient" ] "Response" 0), [])
+          KTCustomType(
+            FQName.Package
+              { owner = "Darklang"
+                modules = [ "Stdlib"; "HttpClient" ]
+                name = TypeName.TypeName "RequestError"
+                version = 0 },
+            []
+          )
         let resultOk = Dval.resultOk responseType KTString
         let typeName = RuntimeError.name [ "HttpClient" ] "RequestError" 0
         let resultError = Dval.resultError responseType (KTCustomType(typeName, []))
@@ -530,6 +537,4 @@ let fns (config : Configuration) : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let constants : List<BuiltInConstant> = []
-
-let contents config = (fns config, types, constants)
+let contents config = (fns config, constants)

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -70,7 +70,7 @@ module RequestError =
     | BadUrl of BadUrl.BadUrlDetails
     | Timeout
     | HeaderError of HeaderError.HeaderError
-    | IOException of string
+    | IOError of string
     | ConnectionError of string
 
   let toDT (err : RequestError) : Ply<Dval> =
@@ -85,7 +85,7 @@ module RequestError =
           | HeaderError err ->
             let! err = HeaderError.toDT err
             return "HeaderError", [ err ]
-          | IOException e -> return "IOException", [ DString e ]
+          | IOError e -> return "IOError", [ DString e ]
           | ConnectionError e -> return "ConnectionError", [ DString e ]
         }
 
@@ -377,7 +377,7 @@ let makeRequest
         return
           Error(RequestError.RequestError.BadUrl BadUrl.BadUrlDetails.InvalidUri)
       | :? IOException as e ->
-        return Error(RequestError.RequestError.IOException e.Message)
+        return Error(RequestError.RequestError.IOError e.Message)
 
       | :? HttpRequestException as e ->
         // This is a bit of an awkward case. I'm unsure how it fits into our model.

--- a/backend/src/BuiltinExecution/Libs/HttpClient.fs
+++ b/backend/src/BuiltinExecution/Libs/HttpClient.fs
@@ -24,8 +24,6 @@ type Request = { url : string; method : Method; headers : Headers.T; body : Body
 
 type Response = { statusCode : int; headers : Headers.T; body : Body }
 
-// forked from Elm's HttpError type
-// https://package.elm-lang.org/packages/elm/http/latest/Http#Error
 
 module HeaderError =
   type HeaderError =
@@ -40,6 +38,8 @@ module HeaderError =
     Dval.enum typeName typeName (Some []) caseName fields
 
 module RequestError =
+  // forked from Elm's HttpError type
+  // https://package.elm-lang.org/packages/elm/http/latest/Http#Error
   type RequestError =
   | BadUrl of details : string
   | Timeout
@@ -452,7 +452,11 @@ let fns (config : Configuration) : List<BuiltInFn> =
                   |> Dval.list (KTTuple(VT.string, VT.string, []))
 
                 let typ =
-                  FQName.BuiltIn(TypeName.builtIn [ "HttpClient" ] "Response" 0)
+                  FQName.Package
+                    { owner = "Darklang"
+                      modules = [ "Stdlib"; "HttpClient" ]
+                      name = TypeName.TypeName "Response"
+                      version = 0 }
 
                 let fields =
                   [ ("statusCode", DInt(int64 response.statusCode))

--- a/backend/src/BuiltinExecution/Libs/Int.fs
+++ b/backend/src/BuiltinExecution/Libs/Int.fs
@@ -12,7 +12,6 @@ open LibExecution.Builtin.Shortcuts
 module VT = ValueType
 module Dval = LibExecution.Dval
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 /// Used for values which are outside the range of expected values for some
@@ -372,4 +371,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Json.fs
+++ b/backend/src/BuiltinExecution/Libs/Json.fs
@@ -609,7 +609,6 @@ let parse
     }
 
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Json" ]
@@ -666,4 +665,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/List.fs
+++ b/backend/src/BuiltinExecution/Libs/List.fs
@@ -220,7 +220,6 @@ let modules = [ "List" ]
 let fn = fn modules
 let constant = constant modules
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -750,4 +749,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Math.fs
+++ b/backend/src/BuiltinExecution/Libs/Math.fs
@@ -21,8 +21,6 @@ let constant = constant modules
 
 let constants : List<BuiltInConstant> = []
 
-let types : List<BuiltInType> = []
-
 let fns : List<BuiltInFn> =
   [ { name = fn "cos" 0
       typeParams = []
@@ -215,4 +213,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/NoModule.fs
+++ b/backend/src/BuiltinExecution/Libs/NoModule.fs
@@ -266,7 +266,6 @@ and equalsMatchPattern (pattern1 : MatchPattern) (pattern2 : MatchPattern) : boo
 
 let varA = TVariable "a"
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn []
@@ -354,4 +353,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/String.fs
+++ b/backend/src/BuiltinExecution/Libs/String.fs
@@ -23,9 +23,7 @@ let modules = [ "String" ]
 let fn = fn modules
 let constant = constant modules
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
-
 
 let fns : List<BuiltInFn> =
   [ { name = fn "map" 0
@@ -467,4 +465,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/Uuid.fs
+++ b/backend/src/BuiltinExecution/Libs/Uuid.fs
@@ -10,7 +10,6 @@ open LibExecution.Builtin.Shortcuts
 module VT = ValueType
 module Dval = LibExecution.Dval
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fn = fn [ "Uuid" ]
@@ -72,4 +71,4 @@ let fns : List<BuiltInFn> =
 
     ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/BuiltinExecution/Libs/X509.fs
+++ b/backend/src/BuiltinExecution/Libs/X509.fs
@@ -13,7 +13,7 @@ module Dval = LibExecution.Dval
 let varA = TVariable "a"
 let varB = TVariable "b"
 
-let types : List<BuiltInType> = []
+
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -58,4 +58,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -42,16 +42,14 @@ let info () =
 // ---------------------
 
 let builtIns : RT.BuiltIns =
-  let (fns, types, constants) =
+  let (fns, constants) =
     LibExecution.Builtin.combine
       [ BuiltinExecution.Builtin.contents
           BuiltinExecution.Libs.HttpClient.defaultConfig
         BuiltinCli.Builtin.contents
         BuiltinCliHost.Builtin.contents ]
       []
-      []
-  { types = types |> Map.fromListBy (fun typ -> typ.name)
-    fns = fns |> Map.fromListBy (fun fn -> fn.name)
+  { fns = fns |> Map.fromListBy (fun fn -> fn.name)
     constants = constants |> Map.fromListBy (fun c -> c.name) }
 
 let packageManager = LibCliExecution.PackageManager.packageManager

--- a/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/ProgramTypesToSerializedTypes.fs
@@ -14,17 +14,6 @@ module NEList =
   let toPT (l : ST.NEList<'a>) : NEList<'a> = { head = l.head; tail = l.tail }
 
 module TypeName =
-
-  module BuiltIn =
-    let toST (b : PT.TypeName.BuiltIn) : ST.TypeName.BuiltIn =
-      let (PT.TypeName.TypeName name) = b.name
-      { modules = b.modules; name = name; version = b.version }
-
-    let toPT (b : ST.TypeName.BuiltIn) : PT.TypeName.BuiltIn =
-      { modules = b.modules
-        name = PT.TypeName.TypeName b.name
-        version = b.version }
-
   module UserProgram =
     let toST (u : PT.TypeName.UserProgram) : ST.TypeName.UserProgram =
       let (PT.TypeName.TypeName name) = u.name
@@ -48,13 +37,13 @@ module TypeName =
 
   let toST (fqtn : PT.TypeName.TypeName) : ST.TypeName.TypeName =
     match fqtn with
-    | PT.FQName.BuiltIn s -> ST.TypeName.BuiltIn(BuiltIn.toST s)
+    | PT.FQName.BuiltIn _s ->
+      LibExecution.RuntimeTypes.raiseString "BuiltIn types not supported"
     | PT.FQName.UserProgram u -> ST.TypeName.UserProgram(UserProgram.toST u)
     | PT.FQName.Package p -> ST.TypeName.Package(Package.toST p)
 
   let toPT (fqfn : ST.TypeName.TypeName) : PT.TypeName.TypeName =
     match fqfn with
-    | ST.TypeName.BuiltIn s -> PT.FQName.BuiltIn(BuiltIn.toPT s)
     | ST.TypeName.UserProgram u -> PT.FQName.UserProgram(UserProgram.toPT u)
     | ST.TypeName.Package p -> PT.FQName.Package(Package.toPT p)
 

--- a/backend/src/LibBinarySerialization/SerializedTypes.fs
+++ b/backend/src/LibBinarySerialization/SerializedTypes.fs
@@ -87,7 +87,6 @@ module TypeName =
 
   [<MessagePack.MessagePackObject>]
   type TypeName =
-    | BuiltIn of BuiltIn
     | UserProgram of UserProgram
     | Package of Package
 

--- a/backend/src/LibCliExecution/PackageManager.fs
+++ b/backend/src/LibCliExecution/PackageManager.fs
@@ -305,14 +305,6 @@ module ExternalTypesToProgramTypes =
       | Negative -> Prelude.Negative
 
   module TypeName =
-    module BuiltIn =
-      let toPT (b : EPT.TypeName.BuiltIn) : PT.TypeName.BuiltIn =
-        { modules = b.modules
-          name =
-            match b.name with
-            | EPT.TypeName.Name.TypeName name -> PT.TypeName.TypeName name
-          version = b.version }
-
     module Package =
       let toPT (p : EPT.TypeName.Package) : PT.TypeName.Package =
         { owner = p.owner
@@ -324,7 +316,7 @@ module ExternalTypesToProgramTypes =
 
     let toPT (fqfn : EPT.TypeName.TypeName) : PT.TypeName.TypeName =
       match fqfn with
-      | EPT.FQName.BuiltIn s -> PT.FQName.BuiltIn(BuiltIn.toPT s)
+      | EPT.FQName.BuiltIn _s -> RT.raiseString "BuiltIn types not supported"
       | EPT.FQName.Package p -> PT.FQName.Package(Package.toPT p)
 
 

--- a/backend/src/LibCloudExecution/CloudExecution.fs
+++ b/backend/src/LibCloudExecution/CloudExecution.fs
@@ -24,11 +24,9 @@ let builtins : LibExecution.Builtin.Contents =
       BuiltinCloudExecution.Builtin.contents
       BuiltinDarkInternal.Builtin.contents ]
     []
-    []
 let builtIns : RT.BuiltIns =
-  let (fns, types, constants) = builtins
-  { types = types |> Map.fromListBy (fun typ -> typ.name)
-    fns = fns |> Map.fromListBy (fun fn -> fn.name)
+  let (fns, constants) = builtins
+  { fns = fns |> Map.fromListBy (fun fn -> fn.name)
     constants = constants |> Map.fromListBy (fun c -> c.name) }
 
 let packageManager = PackageManager.packageManager

--- a/backend/src/LibExecution/Builtin.fs
+++ b/backend/src/LibExecution/Builtin.fs
@@ -4,11 +4,10 @@ module LibExecution.Builtin
 open Prelude
 open RuntimeTypes
 
-type TypeRenames = List<TypeName.BuiltIn * TypeName.BuiltIn>
 type FnRenames = List<FnName.BuiltIn * FnName.BuiltIn>
 
 /// All Libs should expose `contents`, which is a list of all the types and functions it provides
-type Contents = List<BuiltInFn> * List<BuiltInType> * List<BuiltInConstant>
+type Contents = List<BuiltInFn> * List<BuiltInConstant>
 
 
 // To cut down on the amount of code, when we rename a function and make no other
@@ -42,29 +41,6 @@ let renameFunctions
     |> Map.values
   existing @ newFns
 
-let renameTypes
-  (renames : TypeRenames)
-  (existing : List<BuiltInType>)
-  : List<BuiltInType> =
-  let existingMap = existing |> List.map (fun typ -> typ.name, typ) |> Map
-  let newTypes =
-    renames
-    |> List.fold
-      (fun renamedTypes (oldName, newName) ->
-        let newType =
-          Map.find newName (Map.mergeFavoringLeft renamedTypes existingMap)
-          |> Exception.unwrapOptionInternal
-            $"all types should exist {oldName} -> {newName}"
-            [ "oldName", oldName; "newName", newName ]
-        Map.add
-          oldName
-          { newType with
-              name = oldName
-              deprecated = RenamedTo(FQName.BuiltIn newName) }
-          renamedTypes)
-      Map.empty
-    |> Map.values
-  existing @ newTypes
 
 let checkFn (_fn : BuiltInFn) : unit =
   // We can't do this until constants (eg Math.pi) are no longer implemented as functions
@@ -73,31 +49,16 @@ let checkFn (_fn : BuiltInFn) : unit =
   ()
 
 /// Provided a list of library contents, combine them (handling renames)
-let combine
-  (libs : List<Contents>)
-  (fnRenames : FnRenames)
-  (typeRenames : TypeRenames)
-  : Contents =
-  let (fns, types, constants) = List.unzip3 libs
+let combine (libs : List<Contents>) (fnRenames : FnRenames) : Contents =
+  let (fns, constants) = List.unzip libs
   fns |> List.concat |> List.iter checkFn
-  (fns |> List.concat |> renameFunctions fnRenames,
-   types |> List.concat |> renameTypes typeRenames,
-   constants |> List.concat)
+  (fns |> List.concat |> renameFunctions fnRenames, constants |> List.concat)
 
 
 
 module Shortcuts =
   let fn = FnName.builtIn
-  let typ = TypeName.builtIn
   let constant = ConstantName.builtIn
   let incorrectArgs = RuntimeTypes.incorrectArgs
 
   type Param = BuiltInParam
-
-
-  let stdlibTypeRef
-    (modules : List<string>)
-    (name : string)
-    (version : int)
-    : TypeReference =
-    TCustomType(Ok(TypeName.fqBuiltIn modules name version), [])

--- a/backend/src/LibExecution/ProgramTypes.fs
+++ b/backend/src/LibExecution/ProgramTypes.fs
@@ -120,15 +120,12 @@ module FQName =
 module TypeName =
   type Name = TypeName of string
   type TypeName = FQName.FQName<Name>
-  type BuiltIn = FQName.BuiltIn<Name>
   type UserProgram = FQName.UserProgram<Name>
   type Package = FQName.Package<Name>
 
   let pattern = @"^[A-Z][a-z0-9A-Z_']*$"
   let assert' (TypeName name : Name) : unit =
     assertRe "type name must match" pattern name
-  let builtIn (modules : List<string>) (name : string) (version : int) : BuiltIn =
-    FQName.builtin assert' modules (TypeName name) version
 
   let fqBuiltIn (modules : List<string>) (name : string) (version : int) : TypeName =
     FQName.fqBuiltIn assert' modules (TypeName name) version

--- a/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToDarkTypes.fs
@@ -184,11 +184,6 @@ module TypeName =
       | DEnum(_, _, [], "TypeName", [ DString name ]) -> PT.TypeName.TypeName(name)
       | _ -> Exception.raiseInternal "Invalid TypeName" []
 
-  module BuiltIn =
-    let toDT (u : PT.TypeName.BuiltIn) : Dval =
-      FQName.BuiltIn.toDT Name.knownType Name.toDT u
-    let fromDT (d : Dval) : PT.TypeName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
-
   module UserProgram =
     let toDT (u : PT.TypeName.UserProgram) : Dval =
       FQName.UserProgram.toDT Name.knownType Name.toDT u

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -8,16 +8,6 @@ module RT = RuntimeTypes
 module PT = ProgramTypes
 
 module TypeName =
-
-  module BuiltIn =
-    let toRT (s : PT.TypeName.BuiltIn) : RT.TypeName.BuiltIn =
-      let (PT.TypeName.TypeName name) = s.name
-      { modules = s.modules; name = RT.TypeName.TypeName name; version = s.version }
-
-    let fromRT (s : RT.TypeName.BuiltIn) : PT.TypeName.BuiltIn =
-      let (RT.TypeName.TypeName name) = s.name
-      { modules = s.modules; name = PT.TypeName.TypeName name; version = s.version }
-
   module UserProgram =
     let toRT (u : PT.TypeName.UserProgram) : RT.TypeName.UserProgram =
       let (PT.TypeName.TypeName name) = u.name
@@ -44,13 +34,15 @@ module TypeName =
 
   let toRT (fqtn : PT.TypeName.TypeName) : RT.TypeName.TypeName =
     match fqtn with
-    | PT.FQName.BuiltIn s -> RT.FQName.BuiltIn(BuiltIn.toRT s)
+    | PT.FQName.BuiltIn _s ->
+      RT.raiseString "Not sure what to do here - builtin types are no longer a thing"
     | PT.FQName.UserProgram u -> RT.FQName.UserProgram(UserProgram.toRT u)
     | PT.FQName.Package p -> RT.FQName.Package(Package.toRT p)
 
   let fromRT (fqtn : RT.TypeName.TypeName) : Option<PT.TypeName.TypeName> =
     match fqtn with
-    | RT.FQName.BuiltIn s -> PT.FQName.BuiltIn(BuiltIn.fromRT s) |> Some
+    | RT.FQName.BuiltIn _s ->
+      RT.raiseString "Not sure what to do here - builtin types are no longer a thing"
     | RT.FQName.UserProgram u -> PT.FQName.UserProgram(UserProgram.fromRT u) |> Some
     | RT.FQName.Package p -> PT.FQName.Package(Package.fromRT p) |> Some
 

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1,5 +1,5 @@
 /// The core types and functions used by the Dark language's runtime. These
-/// are not idential to the serialized types or the types used in the Editor,
+/// are not identical to the serialized types or the types used in the Editor,
 /// as those have unique constraints (typically, backward compatibility or
 /// continuous delivery).
 module LibExecution.RuntimeTypes

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -157,11 +157,6 @@ module TypeName =
       | DEnum(_, _, [], "TypeName", [ DString name ]) -> TypeName.TypeName(name)
       | _ -> Exception.raiseInternal "Invalid TypeName" []
 
-  module BuiltIn =
-    let toDT (u : TypeName.BuiltIn) : Dval =
-      FQName.BuiltIn.toDT Name.knownType Name.toDT u
-    let fromDT (d : Dval) : TypeName.BuiltIn = FQName.BuiltIn.fromDT Name.fromDT d
-
   module UserProgram =
     let toDT (u : TypeName.UserProgram) : Dval =
       FQName.UserProgram.toDT Name.knownType Name.toDT u

--- a/backend/src/LibParser/Canvas.fs
+++ b/backend/src/LibParser/Canvas.fs
@@ -202,7 +202,7 @@ let toResolver (canvas : WTCanvasModule) : NameResolver.NameResolver =
   let fns = canvas.fns |> List.map (fun fn -> fn.name)
   let types = canvas.types |> List.map (fun typ -> typ.name)
   let constants = canvas.constants |> List.map (fun c -> c.name)
-  NameResolver.create [] [] [] types fns constants true None
+  NameResolver.create [] [] types fns constants true None
 
 let toPT
   (nameResolver : NameResolver.NameResolver)

--- a/backend/src/LibParser/NameResolver.fs
+++ b/backend/src/LibParser/NameResolver.fs
@@ -12,7 +12,6 @@ module NRE = LibExecution.NameResolutionError
 
 type NameResolver =
   {
-    builtinTypes : Set<PT.TypeName.BuiltIn>
     builtinFns : Set<PT.FnName.BuiltIn>
     builtinConstants : Set<PT.ConstantName.BuiltIn>
 
@@ -37,8 +36,7 @@ type NameResolver =
 
 
 let empty : NameResolver =
-  { builtinTypes = Set.empty
-    builtinFns = Set.empty
+  { builtinFns = Set.empty
     builtinConstants = Set.empty
 
     userTypes = Set.empty
@@ -52,7 +50,6 @@ let empty : NameResolver =
 
 
 let create
-  (builtinTypes : List<PT.TypeName.BuiltIn>)
   (builtinFns : List<PT.FnName.BuiltIn>)
   (builtinConstants : List<PT.ConstantName.BuiltIn>)
   (userTypes : List<PT.TypeName.UserProgram>)
@@ -61,8 +58,7 @@ let create
   (allowError : bool)
   (packageManager : Option<RT.PackageManager>)
   : NameResolver =
-  { builtinTypes = Set.ofList builtinTypes
-    builtinFns = Set.ofList builtinFns
+  { builtinFns = Set.ofList builtinFns
     builtinConstants = Set.ofList builtinConstants
 
     userTypes = Set.ofList userTypes
@@ -79,8 +75,7 @@ let merge
   (b : NameResolver)
   (packageManager : Option<RT.PackageManager>)
   : NameResolver =
-  { builtinTypes = Set.union a.builtinTypes b.builtinTypes
-    builtinFns = Set.union a.builtinFns b.builtinFns
+  { builtinFns = Set.union a.builtinFns b.builtinFns
     builtinConstants = Set.union a.builtinConstants b.builtinConstants
 
     userTypes = Set.union a.userTypes b.userTypes
@@ -92,14 +87,8 @@ let merge
     packageManager = packageManager }
 
 
-let fromBuiltins
-  ((fns, types, constants) : LibExecution.Builtin.Contents)
-  : NameResolver =
-  { builtinTypes =
-      types
-      |> List.map (fun typ -> PT2RT.TypeName.BuiltIn.fromRT typ.name)
-      |> Set.ofList
-    builtinFns =
+let fromBuiltins ((fns, constants) : LibExecution.Builtin.Contents) : NameResolver =
+  { builtinFns =
       fns |> List.map (fun fn -> PT2RT.FnName.BuiltIn.fromRT fn.name) |> Set.ofList
 
     builtinConstants =
@@ -117,12 +106,7 @@ let fromBuiltins
 
 
 let fromExecutionState (state : RT.ExecutionState) : NameResolver =
-  { builtinTypes =
-      state.builtIns.types
-      |> Map.keys
-      |> List.map PT2RT.TypeName.BuiltIn.fromRT
-      |> Set.ofList
-    builtinFns =
+  { builtinFns =
       state.builtIns.fns
       |> Map.keys
       |> List.map PT2RT.FnName.BuiltIn.fromRT
@@ -332,7 +316,7 @@ module TypeName =
       PT.TypeName.TypeName
       // TODO: move parsing fn into PT or WT
       FS2WT.Expr.parseTypeName
-      resolver.builtinTypes
+      Set.empty // no builtin types
       resolver.userTypes
       (packageTypeExists resolver.packageManager)
       PT2RT.TypeName.Package.toRT
@@ -351,7 +335,7 @@ module TypeName =
       PT.TypeName.TypeName
       // TODO: move parsing fn into PT or WT
       FS2WT.Expr.parseTypeName
-      resolver.builtinTypes
+      Set.empty // no builtin types
       resolver.userTypes
       (packageTypeExists resolver.packageManager)
       PT2RT.TypeName.Package.toRT

--- a/backend/src/LocalExec/Builtin.fs
+++ b/backend/src/LocalExec/Builtin.fs
@@ -9,11 +9,6 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
 let contents : Builtin.Contents =
   Builtin.combine
     [ Libs.Packages.contents
@@ -22,4 +17,3 @@ let contents : Builtin.Contents =
       Libs.List.contents
       Libs.String.contents ]
     fnRenames
-    typeRenames

--- a/backend/src/LocalExec/Libs/Cli.fs
+++ b/backend/src/LocalExec/Libs/Cli.fs
@@ -14,7 +14,7 @@ module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module Exe = LibExecution.Execution
 
 let builtIns : RT.BuiltIns =
-  let (fns, types, constants) =
+  let (fns, constants) =
     LibExecution.Builtin.combine
       [ BuiltinExecution.Builtin.contents
           BuiltinExecution.Libs.HttpClient.defaultConfig
@@ -22,9 +22,7 @@ let builtIns : RT.BuiltIns =
         BuiltinDarkInternal.Builtin.contents
         BuiltinCliHost.Builtin.contents ]
       []
-      []
-  { types = types |> Map.fromListBy (fun typ -> typ.name)
-    fns = fns |> Map.fromListBy (fun fn -> fn.name)
+  { fns = fns |> Map.fromListBy (fun fn -> fn.name)
     constants = constants |> Map.fromListBy (fun c -> c.name) }
 
 let packageManager : RT.PackageManager = RT.PackageManager.Empty
@@ -77,9 +75,6 @@ let execute
 
 let constants : List<BuiltInConstant> = []
 
-let types : List<BuiltInType> = []
-
-
 let fns : List<BuiltInFn> =
   [ { name = fn [ "LocalExec"; "File" ] "read" 0
       typeParams = []
@@ -105,4 +100,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/LocalExec/Libs/List.fs
+++ b/backend/src/LocalExec/Libs/List.fs
@@ -15,9 +15,7 @@ module TypeChecker = LibExecution.TypeChecker
 
 let varA = TVariable "a"
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
-
 
 let fns : List<BuiltInFn> =
   [ { name = fn [ "LocalExec"; "BuiltIns"; "List" ] "iter" 0
@@ -83,4 +81,4 @@ let fns : List<BuiltInFn> =
 
     ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/LocalExec/Libs/Packages.fs
+++ b/backend/src/LocalExec/Libs/Packages.fs
@@ -24,8 +24,7 @@ let packagePackagesType
     name
     version
 
-
-let types : List<BuiltInType> = []
+let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
   [ { name = fn [ "LocalExec"; "Packages" ] "listFunctions" 0
@@ -156,5 +155,4 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated } ]
 
-let constants : List<BuiltInConstant> = []
-let contents : LibExecution.Builtin.Contents = (fns, types, constants)
+let contents : LibExecution.Builtin.Contents = (fns, constants)

--- a/backend/src/LocalExec/Libs/Packages2.fs
+++ b/backend/src/LocalExec/Libs/Packages2.fs
@@ -30,7 +30,6 @@ let resolver : LibParser.NameResolver.NameResolver =
         BuiltinCloudExecution.Builtin.contents
         BuiltinCliHost.Builtin.contents ]
       []
-      []
     |> LibParser.NameResolver.fromBuiltins
 
   let thisResolver =
@@ -48,7 +47,8 @@ let resolver : LibParser.NameResolver.NameResolver =
 
   LibParser.NameResolver.merge builtinResolver thisResolver (Some packageManager)
 
-
+let packageType =
+  TypeName.fqPackage "Darklang" [ "LocalExec"; "Packages" ] "Package" 0
 
 let fns : List<BuiltInFn> =
   [ { name = fn [ "LocalExec"; "Packages" ] "parse" 0
@@ -56,13 +56,7 @@ let fns : List<BuiltInFn> =
       parameters =
         [ Param.make "package source" TString "The source code of the package"
           Param.make "filename" TString "Used for error message" ]
-      returnType =
-        TypeReference.result
-          (TCustomType(
-            Ok(FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Package" 0)),
-            []
-          ))
-          TString
+      returnType = TypeReference.result (TCustomType(Ok packageType, [])) TString
       description = "Parse a package"
       fn =
         function
@@ -77,17 +71,16 @@ let fns : List<BuiltInFn> =
             let packagesTypes = types |> List.map PT2DT.PackageType.toDT
             let packagesConstants = constants |> List.map PT2DT.PackageConstant.toDT
 
-            let typeName =
-              FQName.BuiltIn(typ [ "LocalExec"; "Packages" ] "Package" 0)
+            let typeName = packageType
             let fields =
-              [ "fns", DList(VT.customType PT2DT.PackageFn.typeName [], packagesFns)
-                "types",
-                DList(VT.customType PT2DT.PackageType.typeName [], packagesTypes)
-                "constants",
-                DList(
-                  VT.customType PT2DT.PackageConstant.typeName [],
-                  packagesConstants
-                ) ]
+              [ ("fns", DList(VT.customType PT2DT.PackageFn.typeName [], packagesFns))
+                ("types",
+                 DList(VT.customType PT2DT.PackageType.typeName [], packagesTypes))
+                ("constants",
+                 DList(
+                   VT.customType PT2DT.PackageConstant.typeName [],
+                   packagesConstants
+                 )) ]
             return
               DRecord(typeName, typeName, [], Map fields)
               |> Dval.resultOk (KTCustomType(typeName, [])) KTString
@@ -98,4 +91,4 @@ let fns : List<BuiltInFn> =
       deprecated = NotDeprecated } ]
 
 
-let contents : LibExecution.Builtin.Contents = (fns, [], [])
+let contents : LibExecution.Builtin.Contents = (fns, [])

--- a/backend/src/LocalExec/Libs/String.fs
+++ b/backend/src/LocalExec/Libs/String.fs
@@ -8,7 +8,6 @@ open Prelude
 open LibExecution.RuntimeTypes
 open LibExecution.Builtin.Shortcuts
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> = []
 
 let fns : List<BuiltInFn> =
@@ -28,4 +27,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/src/LocalExec/LocalExec.fs
+++ b/backend/src/LocalExec/LocalExec.fs
@@ -15,7 +15,7 @@ module BuiltinCli = BuiltinCli.Builtin
 
 
 let builtIns : RT.BuiltIns =
-  let (fns, types, constants) =
+  let (fns, constants) =
     LibExecution.Builtin.combine
       [ BuiltinExecution.Builtin.contents
           BuiltinExecution.Libs.HttpClient.defaultConfig
@@ -25,9 +25,7 @@ let builtIns : RT.BuiltIns =
         BuiltinCloudExecution.Builtin.contents
         TestUtils.LibTest.contents ]
       []
-      []
-  { types = types |> Map.fromListBy (fun typ -> typ.name)
-    fns = fns |> Map.fromListBy (fun fn -> fn.name)
+  { fns = fns |> Map.fromListBy (fun fn -> fn.name)
     constants = constants |> Map.fromListBy (fun c -> c.name) }
 
 
@@ -209,7 +207,6 @@ module PackageBootstrapping =
       let nameResolver =
         LibParser.NameResolver.fromBuiltins (
           Map.values builtIns.fns |> Seq.toList,
-          Map.values builtIns.types |> Seq.toList,
           Map.values builtIns.constants |> Seq.toList
         )
         |> fun nr -> { nr with allowError = true }
@@ -270,7 +267,6 @@ let runLocalExecScript (args : string[]) : Ply<int> =
       // TODO: this may need more builtins, and packages
       LibParser.NameResolver.fromBuiltins (
         Map.values builtIns.fns |> Seq.toList,
-        Map.values builtIns.types |> Seq.toList,
         Map.values builtIns.constants |> Seq.toList
       )
 

--- a/backend/src/Wasm/Builtin.fs
+++ b/backend/src/Wasm/Builtin.fs
@@ -11,9 +11,4 @@ let fnRenames : Builtin.FnRenames =
   // eg: fn "Http" "respond" 0, fn "Http" "response" 0
   []
 
-let typeRenames : Builtin.TypeRenames =
-  // old names, new names
-  // eg: typ "Http" "Response" 0, typ "Http" "Response" 1
-  []
-
-let contents = Builtin.combine [ Libs.Editor.contents ] fnRenames typeRenames
+let contents = Builtin.combine [ Libs.Editor.contents ] fnRenames

--- a/backend/src/Wasm/DarkEditor.fs
+++ b/backend/src/Wasm/DarkEditor.fs
@@ -33,7 +33,6 @@ let builtin =
   LibExecution.Builtin.combine
     [ BuiltinExecution.Builtin.contents httpConfig; Builtin.contents ]
     []
-    []
 
 
 /// Load the Darklang program that manages the state of and interactions with

--- a/backend/src/Wasm/EvalHelpers.fs
+++ b/backend/src/Wasm/EvalHelpers.fs
@@ -13,10 +13,9 @@ let getStateForEval
   : ExecutionState =
 
   let builtIns : BuiltIns =
-    let builtInFns, builtInTypes, builtInConstants = builtin
-    { types = builtInTypes |> List.map (fun typ -> typ.name, typ) |> Map
-      fns = builtInFns |> List.map (fun fn -> fn.name, fn) |> Map
-      constants = builtInConstants |> List.map (fun c -> c.name, c) |> Map }
+    let (fns, constants) = builtin
+    { fns = fns |> List.map (fun fn -> fn.name, fn) |> Map
+      constants = constants |> List.map (fun c -> c.name, c) |> Map }
 
   // TODO
   let packageManager : PackageManager = PackageManager.Empty

--- a/backend/src/Wasm/Libs/Editor.fs
+++ b/backend/src/Wasm/Libs/Editor.fs
@@ -13,9 +13,6 @@ module VT = ValueType
 module Dval = LibExecution.Dval
 module TypeChecker = LibExecution.TypeChecker
 
-let types : List<BuiltInType> = []
-let constants : List<BuiltInConstant> = []
-
 
 type Editor =
   { Types : List<UserType.T>
@@ -35,6 +32,11 @@ type UserProgramSource =
 // this is client.dark, loaded and live, along with some current state
 let mutable editor : Editor =
   { Types = []; Functions = []; Constants = []; CurrentState = DUnit }
+
+
+
+let constants : List<BuiltInConstant> = []
+
 
 let fn = fn [ "WASM"; "Editor" ]
 
@@ -152,7 +154,6 @@ let fns : List<BuiltInFn> =
               LibExecution.Builtin.combine
                 [ BuiltinExecution.Builtin.contents httpConfig ]
                 []
-                []
 
             let! result =
               let expr = exprsCollapsedIntoOne source.exprs
@@ -176,4 +177,4 @@ let fns : List<BuiltInFn> =
 
     ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -138,7 +138,9 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "ftp://darklang.com"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol"
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+    PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.UnsupportedProtocol
+  )
 )
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -146,7 +148,9 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "file:///etc/passwd"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol"
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+    PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.UnsupportedProtocol
+  )
 )
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -154,7 +158,9 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "/just-a-path"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol"
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+    PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.UnsupportedProtocol
+  )
 )
 
 // totally bogus URLs
@@ -163,7 +169,11 @@ PACKAGE.Darklang.Stdlib.HttpClient.request "get" "" [] Builtin.Bytes.empty = PAC
   .Stdlib
   .Result
   .Result
-  .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
+  .Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidUri
+    )
+  )
 
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -171,7 +181,9 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "{ ] nonsense ^#( :"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI"
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+    PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidUri
+  )
 )
 
 // URLs we can't actually communicate with
@@ -191,7 +203,9 @@ module Disallowed =
     "http://0.0.0.0"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE
@@ -199,7 +213,11 @@ module Disallowed =
     .Stdlib
     .Result
     .Result
-    .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    .Error(
+      PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+        PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+      )
+    )
 
 // Check for banned urls in the host name
 module Disallowed =
@@ -209,7 +227,9 @@ module Disallowed =
     "http://0.0.0.0"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE
@@ -217,14 +237,18 @@ module Disallowed =
     .Stdlib
     .Result
     .Result
-    .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    .Error(
+      PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+        PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+      )
+    )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:0:0:0]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::]:80) Could not connect"
   )
 
@@ -233,14 +257,20 @@ module Disallowed =
     .Stdlib
     .Result
     .Result
-    .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
+    .Error(
+      PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+        PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidUri
+      )
+    )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://localhost"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -248,7 +278,9 @@ module Disallowed =
     "http://127.0.0.1"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -256,7 +288,7 @@ module Disallowed =
     "http://[::1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::1]:80) Could not connect"
   )
 
@@ -265,7 +297,7 @@ module Disallowed =
     "http://[0:0:0:0:0:0:0:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::1]:80) Could not connect"
   )
 
@@ -274,7 +306,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:0000:0000:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::1]:80) Could not connect"
   )
 
@@ -283,7 +315,9 @@ module Disallowed =
     "http://127.0.0.17"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -291,7 +325,7 @@ module Disallowed =
     "http://[::ffff:7f00:11]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
@@ -300,7 +334,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
@@ -309,7 +343,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
@@ -318,7 +352,9 @@ module Disallowed =
     "http://127.255.174.17"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
 
@@ -327,7 +363,9 @@ module Disallowed =
     "http://metadata.google.internal"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -335,7 +373,9 @@ module Disallowed =
     "http://metadata"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -343,7 +383,9 @@ module Disallowed =
     "http://169.254.169.254"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -351,7 +393,7 @@ module Disallowed =
     "http://[::ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
@@ -360,7 +402,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
@@ -369,7 +411,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
@@ -378,7 +420,9 @@ module Disallowed =
     "http://169.254.0.0"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -386,7 +430,9 @@ module Disallowed =
     "http://172.16.0.1"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -394,7 +440,7 @@ module Disallowed =
     "http://[::ffff:ac10:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
@@ -403,7 +449,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
@@ -412,7 +458,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
@@ -421,7 +467,9 @@ module Disallowed =
     "http://192.168.1.1"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidHost
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -429,7 +477,7 @@ module Disallowed =
     "http://[::ffff:c0a8:101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
@@ -438,7 +486,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
@@ -447,7 +495,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
@@ -458,7 +506,7 @@ module Disallowed =
     "http://localtest.me"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect (localtest.me:80) Could not connect"
   )
   // 0.0.0.0
@@ -467,7 +515,7 @@ module Disallowed =
     "http://c.cx"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Could not connect (c.cx:80) Could not connect"
   )
 
@@ -477,7 +525,9 @@ module Disallowed =
     "http://google.com"
     [ ("Metadata-Flavor", "Google") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidRequest
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -485,7 +535,9 @@ module Disallowed =
     "http://google.com"
     [ ("metadata-flavor", "Google") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidRequest
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -493,7 +545,9 @@ module Disallowed =
     "http://google.com"
     [ ("Metadata-Flavor", "google") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidRequest
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -501,7 +555,9 @@ module Disallowed =
     "http://google.com"
     [ ("Metadata-Flavor", " Google ") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidRequest
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -509,7 +565,9 @@ module Disallowed =
     "http://google.com"
     [ ("X-Google-Metadata-Request", " True ") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidRequest
+    )
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -517,7 +575,9 @@ module Disallowed =
     "http://google.com"
     [ (" x-Google-metaData-Request", " True ") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl(
+      PACKAGE.Darklang.Stdlib.HttpClient.BadUrlDetails.InvalidRequest
+    )
   )
 
 module BadSSL =
@@ -526,7 +586,7 @@ module BadSSL =
     "http://thenonexistingurlforsure.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known"
   )
 
@@ -535,7 +595,7 @@ module BadSSL =
     "https://self-signed.badssl.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
       "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot"
   )
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -173,14 +173,6 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
 // Check for banned urls in the host name
 module Disallowed =
 
-// PACKAGE.Darklang.Stdlib.HttpClient.request
-//   "get"
-//   "http://google.com:79"
-//   []
-//   Builtin.Bytes.empty |> Result.mapError HttpClient.rqError.toString = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-//   "timeout"
-// )
-
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://0.0.0.0"

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -249,7 +249,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request "get" "localhost" [] Builtin.Bytes.empty = PACKAGE
@@ -289,7 +288,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -298,7 +296,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -307,7 +304,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -326,7 +322,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -335,7 +330,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -344,7 +338,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -394,7 +387,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -403,7 +395,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -412,7 +403,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -441,7 +431,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -450,7 +439,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -459,7 +447,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -478,7 +465,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -487,7 +473,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -496,7 +481,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
   // Check for sneaky banned urls - blocked via connection callback
@@ -507,7 +491,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect (localtest.me:80) Could not connect"
   )
   // 0.0.0.0
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -516,7 +499,6 @@ module Disallowed =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Could not connect (c.cx:80) Could not connect"
   )
 
   // invalid headers
@@ -587,7 +569,6 @@ module BadSSL =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known"
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -596,7 +577,6 @@ module BadSSL =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
-      "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot"
   )
 
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -106,7 +106,9 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "https://darklang.com"
   [ ("", "") ]
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-  PACKAGE.Darklang.Stdlib.HttpClient.BadHeader.EmptyKey
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadHeader(
+    PACKAGE.Darklang.Stdlib.HttpClient.BadHeader.EmptyKey
+  )
 )
 
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -106,7 +106,7 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "https://darklang.com"
   [ ("", "") ]
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-  PACKAGE.Darklang.Stdlib.HttpClient.HeaderError.EmptyKey
+  PACKAGE.Darklang.Stdlib.HttpClient.BadHeader.EmptyKey
 )
 
 
@@ -115,22 +115,25 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   ""
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadMethod
+)
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   " get "
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadMethod
+)
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "🇵🇷"
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadMethod
+)
 
 // unsupported protocols
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -248,7 +251,7 @@ module Disallowed =
     "http://[0:0:0:0:0:0:0:0]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request "get" "localhost" [] Builtin.Bytes.empty = PACKAGE
@@ -287,7 +290,7 @@ module Disallowed =
     "http://[::1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -295,7 +298,7 @@ module Disallowed =
     "http://[0:0:0:0:0:0:0:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -303,7 +306,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:0000:0000:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -321,7 +324,7 @@ module Disallowed =
     "http://[::ffff:7f00:11]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -329,7 +332,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -337,7 +340,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -386,7 +389,7 @@ module Disallowed =
     "http://[::ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -394,7 +397,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -402,7 +405,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -430,7 +433,7 @@ module Disallowed =
     "http://[::ffff:ac10:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -438,7 +441,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -446,7 +449,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -464,7 +467,7 @@ module Disallowed =
     "http://[::ffff:c0a8:101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -472,7 +475,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -480,7 +483,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   // Check for sneaky banned urls - blocked via connection callback
@@ -490,7 +493,7 @@ module Disallowed =
     "http://localtest.me"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
   // 0.0.0.0
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -498,7 +501,7 @@ module Disallowed =
     "http://c.cx"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   // invalid headers
@@ -568,7 +571,7 @@ module BadSSL =
     "http://thenonexistingurlforsure.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -576,7 +579,7 @@ module BadSSL =
     "https://self-signed.badssl.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.NetworkError
   )
 
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -105,8 +105,9 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "get"
   "https://darklang.com"
   [ ("", "") ]
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Empty request header key provided"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+   PACKAGE.Darklang.Stdlib.HttpClient.HeaderError.EmptyKey)
+
 
 // type errors for bad `method` are OK
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -120,56 +121,75 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   " get "
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "🇵🇷"
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
 
 // unsupported protocols
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "get"
   "ftp://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Bad URL: Unsupported Protocol"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol")
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "put"
   "file:///etc/passwd"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Bad URL: Unsupported Protocol"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol")
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "put"
   "/just-a-path"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Bad URL: Unsupported Protocol"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol")
 
 // totally bogus URLs
-PACKAGE.Darklang.Stdlib.HttpClient.request "get" "" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Bad URL: Invalid URI"
+PACKAGE.Darklang.Stdlib.HttpClient.request "get" "" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
+
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "post"
   "{ ] nonsense ^#( :"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Bad URL: Invalid URI"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
 
 // URLs we can't actually communicate with
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "get"
   "http://google.com:79"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-  "Request timed out"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error( PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Timeout)
+
+// Check for banned urls in the host name
+module Disallowed =
+
+// PACKAGE.Darklang.Stdlib.HttpClient.request
+//   "get"
+//   "http://google.com:79"
+//   []
+//   Builtin.Bytes.empty |> Result.mapError HttpClient.rqError.toString = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+//   "timeout"
+// )
+
+  PACKAGE.Darklang.Stdlib.HttpClient.request
+    "get"
+    "http://0.0.0.0"
+    []
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+
+  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
 // Check for banned urls in the host name
 module Disallowed =
@@ -178,197 +198,197 @@ module Disallowed =
     "get"
     "http://0.0.0.0"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
-  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:0:0:0]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::]:80) Could not connect")
 
-  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "localhost" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid URI"
+  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "localhost" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://localhost"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://127.0.0.1"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::1]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:0:0:1]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:0000:0000:0001]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://127.0.0.17"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:7f00:11]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:127.0.0.17]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:7f00:0011]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:127.0.0.17]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:7f00:0011]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:127.0.0.17]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://127.255.174.17"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://metadata.google.internal"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://metadata"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://169.254.169.254"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:a9fe:a9fe]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:169.254.169.254]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:a9fe:a9fe]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:169.254.169.254]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:a9fe:a9fe]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:169.254.169.254]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://169.254.0.0"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://172.16.0.1"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:ac10:1]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:172.16.0.1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:ac10:0001]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:172.16.0.1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:ac10:0001]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:172.16.0.1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://192.168.1.1"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid host"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:c0a8:101]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:192.168.1.1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:c0a8:0101]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:192.168.1.1]:80) Could not connect")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:c0a8:0101]"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:192.168.1.1]:80) Could not connect")
 
   // Check for sneaky banned urls - blocked via connection callback
   // 127.0.0.1
@@ -376,73 +396,74 @@ module Disallowed =
     "get"
     "http://localtest.me"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect (localtest.me:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect (localtest.me:80) Could not connect")
   // 0.0.0.0
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://c.cx"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Could not connect (c.cx:80) Could not connect"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect (c.cx:80) Could not connect")
 
   // invalid headers
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("Metadata-Flavor", "Google") ]
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid request"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("metadata-flavor", "Google") ]
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid request"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("Metadata-Flavor", "google") ]
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid request"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("Metadata-Flavor", " Google ") ]
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid request"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+      PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("X-Google-Metadata-Request", " True ") ]
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid request"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ (" x-Google-metaData-Request", " True ") ]
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Bad URL: Invalid request"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
 
 module BadSSL =
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://thenonexistingurlforsure.com"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "https://self-signed.badssl.com"
     []
-    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
-    "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot"
+    Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+     "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot")
 
 
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -248,7 +248,7 @@ module Disallowed =
     "http://[0:0:0:0:0:0:0:0]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::]:80) Could not connect"
   )
 
@@ -288,7 +288,7 @@ module Disallowed =
     "http://[::1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::1]:80) Could not connect"
   )
 
@@ -297,7 +297,7 @@ module Disallowed =
     "http://[0:0:0:0:0:0:0:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::1]:80) Could not connect"
   )
 
@@ -306,7 +306,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:0000:0000:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::1]:80) Could not connect"
   )
 
@@ -325,7 +325,7 @@ module Disallowed =
     "http://[::ffff:7f00:11]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
@@ -334,7 +334,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
@@ -343,7 +343,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
   )
 
@@ -393,7 +393,7 @@ module Disallowed =
     "http://[::ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
@@ -402,7 +402,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
@@ -411,7 +411,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
   )
 
@@ -440,7 +440,7 @@ module Disallowed =
     "http://[::ffff:ac10:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
@@ -449,7 +449,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
@@ -458,7 +458,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
   )
 
@@ -477,7 +477,7 @@ module Disallowed =
     "http://[::ffff:c0a8:101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
@@ -486,7 +486,7 @@ module Disallowed =
     "http://[0:0:0:0:0:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
@@ -495,7 +495,7 @@ module Disallowed =
     "http://[0000:0000:0000:0000:0000:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
   )
 
@@ -506,7 +506,7 @@ module Disallowed =
     "http://localtest.me"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect (localtest.me:80) Could not connect"
   )
   // 0.0.0.0
@@ -515,7 +515,7 @@ module Disallowed =
     "http://c.cx"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Could not connect (c.cx:80) Could not connect"
   )
 
@@ -586,7 +586,7 @@ module BadSSL =
     "http://thenonexistingurlforsure.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known"
   )
 
@@ -595,7 +595,7 @@ module BadSSL =
     "https://self-signed.badssl.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.HttpRequestException
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.ConnectionError
       "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot"
   )
 

--- a/backend/testfiles/execution/stdlib/httpclient.dark
+++ b/backend/testfiles/execution/stdlib/httpclient.dark
@@ -106,7 +106,8 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "https://darklang.com"
   [ ("", "") ]
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-   PACKAGE.Darklang.Stdlib.HttpClient.HeaderError.EmptyKey)
+  PACKAGE.Darklang.Stdlib.HttpClient.HeaderError.EmptyKey
+)
 
 
 // type errors for bad `method` are OK
@@ -121,13 +122,15 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   " get "
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Expected valid HTTP method (e.g. 'get' or 'POST')"
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "🇵🇷"
   "https://darklang.com"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error "Expected valid HTTP method (e.g. 'get' or 'POST')"
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error
+  "Expected valid HTTP method (e.g. 'get' or 'POST')"
 
 // unsupported protocols
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -135,25 +138,32 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "ftp://darklang.com"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol")
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol"
+)
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "put"
   "file:///etc/passwd"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol")
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol"
+)
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "put"
   "/just-a-path"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol")
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Unsupported Protocol"
+)
 
 // totally bogus URLs
-PACKAGE.Darklang.Stdlib.HttpClient.request "get" "" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
+PACKAGE.Darklang.Stdlib.HttpClient.request "get" "" [] Builtin.Bytes.empty = PACKAGE
+  .Darklang
+  .Stdlib
+  .Result
+  .Result
+  .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
 
 
 PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -161,14 +171,17 @@ PACKAGE.Darklang.Stdlib.HttpClient.request
   "{ ] nonsense ^#( :"
   []
   Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI"
+)
 
 // URLs we can't actually communicate with
 PACKAGE.Darklang.Stdlib.HttpClient.request
   "get"
   "http://google.com:79"
   []
-  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error( PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Timeout)
+  Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
+  PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Timeout
+)
 
 // Check for banned urls in the host name
 module Disallowed =
@@ -178,10 +191,15 @@ module Disallowed =
     "http://0.0.0.0"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
-  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
 // Check for banned urls in the host name
 module Disallowed =
@@ -191,90 +209,117 @@ module Disallowed =
     "http://0.0.0.0"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
-  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://0" [] Builtin.Bytes.empty = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:0:0:0]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::]:80) Could not connect"
+  )
 
-  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "localhost" [] Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
+  PACKAGE.Darklang.Stdlib.HttpClient.request "get" "localhost" [] Builtin.Bytes.empty = PACKAGE
+    .Darklang
+    .Stdlib
+    .Result
+    .Result
+    .Error(PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid URI")
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://localhost"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://127.0.0.1"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:0:0:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:0000:0000:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://127.0.0.17"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:7f00:11]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:127.0.0.17]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:127.0.0.17]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:7f00:0011]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:127.0.0.17]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:127.0.0.17]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://127.255.174.17"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -282,105 +327,129 @@ module Disallowed =
     "http://metadata.google.internal"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://metadata"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://169.254.169.254"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:169.254.169.254]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:169.254.169.254]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:a9fe:a9fe]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:169.254.169.254]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:169.254.169.254]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://169.254.0.0"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://172.16.0.1"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:ac10:1]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:172.16.0.1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:172.16.0.1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:ac10:0001]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:172.16.0.1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:172.16.0.1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://192.168.1.1"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid host"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[::ffff:c0a8:101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:192.168.1.1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0:0:0:0:0:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:192.168.1.1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://[0000:0000:0000:0000:0000:ffff:c0a8:0101]"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect ([::ffff:192.168.1.1]:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect ([::ffff:192.168.1.1]:80) Could not connect"
+  )
 
   // Check for sneaky banned urls - blocked via connection callback
   // 127.0.0.1
@@ -389,14 +458,18 @@ module Disallowed =
     "http://localtest.me"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect (localtest.me:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect (localtest.me:80) Could not connect"
+  )
   // 0.0.0.0
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://c.cx"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Could not connect (c.cx:80) Could not connect")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Could not connect (c.cx:80) Could not connect"
+  )
 
   // invalid headers
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -404,42 +477,48 @@ module Disallowed =
     "http://google.com"
     [ ("Metadata-Flavor", "Google") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("metadata-flavor", "Google") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("Metadata-Flavor", "google") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("Metadata-Flavor", " Google ") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-      PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ ("X-Google-Metadata-Request", " True ") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
     "http://google.com"
     [ (" x-Google-metaData-Request", " True ") ]
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.BadUrl "Invalid request"
+  )
 
 module BadSSL =
   PACKAGE.Darklang.Stdlib.HttpClient.request
@@ -447,7 +526,9 @@ module BadSSL =
     "http://thenonexistingurlforsure.com"
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
-    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known")
+    PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
+      "Name or service not known (thenonexistingurlforsure.com:80) Name or service not known"
+  )
 
   PACKAGE.Darklang.Stdlib.HttpClient.request
     "get"
@@ -455,7 +536,8 @@ module BadSSL =
     []
     Builtin.Bytes.empty = PACKAGE.Darklang.Stdlib.Result.Result.Error(
     PACKAGE.Darklang.Stdlib.HttpClient.RequestError.Other
-     "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot")
+      "The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot"
+  )
 
 
 

--- a/backend/testfiles/httpclient/v0/_request-content-type-empty.test
+++ b/backend/testfiles/httpclient/v0/_request-content-type-empty.test
@@ -16,7 +16,7 @@ Hello back
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     {
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/_response-cookie.test
+++ b/backend/testfiles/httpclient/v0/_response-cookie.test
@@ -19,7 +19,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/_response-redirect-304.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-304.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 304
       headers =
         [

--- a/backend/testfiles/httpclient/v0/_response-redirect-destination.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-destination.test
@@ -17,7 +17,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/_response-redirect-to-same-place-absolute.test
+++ b/backend/testfiles/httpclient/v0/_response-redirect-to-same-place-absolute.test
@@ -13,7 +13,7 @@ Location: http://URL
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 302
       headers =
         [

--- a/backend/testfiles/httpclient/v0/_uri-with-auth-both.test
+++ b/backend/testfiles/httpclient/v0/_uri-with-auth-both.test
@@ -17,7 +17,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://user:password@URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/_uri-with-path-fragment.test
+++ b/backend/testfiles/httpclient/v0/_uri-with-path-fragment.test
@@ -16,7 +16,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL?q=5#row=5-👨‍👩‍👧‍👦" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/basic-delete.test
+++ b/backend/testfiles/httpclient/v0/basic-delete.test
@@ -15,7 +15,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "delete" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-get.test
+++ b/backend/testfiles/httpclient/v0/basic-get.test
@@ -15,7 +15,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-head-returns-body.test
+++ b/backend/testfiles/httpclient/v0/basic-head-returns-body.test
@@ -18,7 +18,7 @@ Here's a body!
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "head" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-head.test
+++ b/backend/testfiles/httpclient/v0/basic-head.test
@@ -14,7 +14,7 @@ Content-Length: 568
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "head" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-options.test
+++ b/backend/testfiles/httpclient/v0/basic-options.test
@@ -15,7 +15,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "options" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-patch.test
+++ b/backend/testfiles/httpclient/v0/basic-patch.test
@@ -17,7 +17,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "patch" "http://URL" [("Content-Type", "application/json; charset=utf-8")] ("5" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-post.test
+++ b/backend/testfiles/httpclient/v0/basic-post.test
@@ -16,7 +16,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" [] ("-1" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/basic-put.test
+++ b/backend/testfiles/httpclient/v0/basic-put.test
@@ -18,7 +18,7 @@ Hello back
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "put" "http://URL" reqHeaders ("string" |> PACKAGE.Darklang.Stdlib.String.toBytes)) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/request-content-type-unknown-charset.test
+++ b/backend/testfiles/httpclient/v0/request-content-type-unknown-charset.test
@@ -18,7 +18,7 @@ Hello back
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/request-content-type-unknown-ct.test
+++ b/backend/testfiles/httpclient/v0/request-content-type-unknown-ct.test
@@ -18,7 +18,7 @@ Hello back
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/request-form-simple.test
+++ b/backend/testfiles/httpclient/v0/request-form-simple.test
@@ -16,7 +16,7 @@ Content-Length: 0
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" reqHeaders Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/request-query-param-float.test
+++ b/backend/testfiles/httpclient/v0/request-query-param-float.test
@@ -15,7 +15,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL?f=5.7&n=-0.0&l=1231325345345345.34534534634634634" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/request-query-param-int.test
+++ b/backend/testfiles/httpclient/v0/request-query-param-int.test
@@ -16,7 +16,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL?i=5&n=-1" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-header-duplicate.test
+++ b/backend/testfiles/httpclient/v0/response-header-duplicate.test
@@ -17,7 +17,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-300.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-300.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 300
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-301.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-301.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 301
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-302.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-302.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 302
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-303.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-303.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h ->PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 303
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-305.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-305.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 305
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-306.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-306.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 306
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-307.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-307.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 307
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-308.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-308.test
@@ -13,7 +13,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 308
       headers =
         [

--- a/backend/testfiles/httpclient/v0/response-redirect-to-file.test
+++ b/backend/testfiles/httpclient/v0/response-redirect-to-file.test
@@ -13,7 +13,7 @@ Location: file:////etc/passwd
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 301
       headers =
         [

--- a/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-charset.test
@@ -22,7 +22,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" reqBody {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
 {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = ""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-no-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/request-form-with-body-and-no-charset.test
@@ -19,7 +19,7 @@ var1=2&var2=[]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" {x=6; y=false; z = "str"} {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
 {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-get.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-get.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post-bad.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post-bad.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "morethansix" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-content-length-post.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "morethansix" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-header-override-default.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-override-default.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-header-string.test
+++ b/backend/testfiles/httpclient/v0/todo/request-header-string.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-multipart-form-with-body-and-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/request-multipart-form-with-body-and-charset.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" [] {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
 {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = ""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-list.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-list.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [HttpClient.ContentType.json_v0] { l = [1;2;"a string"; [6]] }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-null.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-null.test
@@ -17,7 +17,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [HttpClient.ContentType.json_v0] { x = null }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-basic.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-basic.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-key.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-emoji-value.test
@@ -20,7 +20,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query {}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-key.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-value.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-values.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-empty-values.test
@@ -20,7 +20,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-key.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-punctuation-value.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-key.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-key.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-value.test
+++ b/backend/testfiles/httpclient/v0/todo/request-query-param-string-spaces-value.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" query [HttpClient.ContentType.json_v0]) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-body-invalid-string.test
+++ b/backend/testfiles/httpclient/v0/todo/response-body-invalid-string.test
@@ -17,7 +17,7 @@ RANDOM_BYTES
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "utf-8 decoding error"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-body-unicode.test
+++ b/backend/testfiles/httpclient/v0/todo/response-body-unicode.test
@@ -16,7 +16,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = """👱👱🏻👱🏼👱🏽👱🏾👱🏿", "👨‍❤️‍💋‍👨", "﷽﷽﷽"""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-content-encoding-brotli.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-encoding-brotli.test
@@ -18,7 +18,7 @@ Content-Encoding: br
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-content-encoding-deflate.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-encoding-deflate.test
@@ -18,7 +18,7 @@ Content-Encoding: deflate
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-content-encoding-gzipped.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-encoding-gzipped.test
@@ -18,7 +18,7 @@ Content-Encoding: gzip
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-content-type-invalid.test
+++ b/backend/testfiles/httpclient/v0/todo/response-content-type-invalid.test
@@ -18,7 +18,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-form-encoded.test
+++ b/backend/testfiles/httpclient/v0/todo/response-form-encoded.test
@@ -19,7 +19,7 @@ var1=2&var2=[]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
 {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-form-with-body-and-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/response-form-with-body-and-charset.test
@@ -19,7 +19,7 @@ var1=2&var2=[]
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
 {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-form-with-body-no-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/response-form-with-body-no-charset.test
@@ -20,7 +20,7 @@ var1=2&var2=[]
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "var1=2&var2=[]"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-header-empty.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-empty.test
@@ -18,7 +18,7 @@ Some-Header:
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-header-int.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-int.test
@@ -18,7 +18,7 @@ Some-Header: 5
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-header-lowercase.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-lowercase.test
@@ -20,7 +20,7 @@ OneVVord: MixedCase
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-header-object.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-object.test
@@ -18,7 +18,7 @@ Some-Header: {}
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-header-string.test
+++ b/backend/testfiles/httpclient/v0/todo/response-header-string.test
@@ -18,7 +18,7 @@ Some-Header: string
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset-dest.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset-dest.test
@@ -19,7 +19,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-conflicting-charset.test
@@ -17,7 +17,7 @@ Date: xxx, xx xxx xxxx xx:xx:xx xxx
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       error = ""

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-delete.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-delete.test
@@ -17,7 +17,7 @@ Location: /v0/response-redirect-destination
  | Error response ->
     let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
     {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = ""
       statusCode = 302
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-no-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/x-www-form-urlencoded"}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-form-urlencoded-content-type-with-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} {"Content-Type" = "application/x-www-form-urlencoded"}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-no-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/json"}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-json-content-type-with-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} {"Content-Type" = "application/json"}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-no-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-no-content-type-with-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-no-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8")}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-plain-content-type-with-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} {("content-type", "text/plain; charset=utf-8")}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-no-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "text/askdjnkajsfunr"}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-post-with-weird-content-type-with-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} {"Content-Type" = "text/askdjnkajsfunr"}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-no-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "put" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8")}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-put-with-content-type-with-body.test
@@ -20,7 +20,7 @@ Redirect destination reached
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "put" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8")}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-auth-header.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-auth-header.test
@@ -21,7 +21,7 @@ Redirect destination reached with auth
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached with auth"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-cookies.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-cookies.test
@@ -21,7 +21,7 @@ Redirect destination reached with cookies
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached with cookies"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-query-params.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-dest-with-query-params.test
@@ -18,7 +18,7 @@ Redirect destination reached with params
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" { value = "x" } {}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached with params"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-no-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-form-urlencoded-content-type-no-b
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/x-www-form-urlencoded" }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-form-urlencoded-content-type-with-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-form-urlencoded-content-type-with
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "body" {} {"Content-Type" = "application/x-www-form-urlencoded" }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-no-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-json-content-type-no-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "application/json" }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-json-content-type-with-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-json-content-type-with-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "body" {} {"Content-Type" = "application/json" }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-no-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-no-content-type-no-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-no-content-type-with-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-no-content-type-with-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "body" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-no-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-plain-content-type-no-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8") }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-plain-content-type-with-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-plain-content-type-with-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "body" {} {("content-type", "text/plain; charset=utf-8") }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-no-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-weird-content-type-no-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "" {} {"Content-Type" = "text/askdjnkajsfunr" }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-post-with-weird-content-type-with-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-post-with-weird-content-type-with-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "post" "http://URL" "body" {} {"Content-Type" = "text/askdjnkajsfunr" }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-no-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-no-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-put-with-content-type-no-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "put" "http://URL" "" {} {("content-type", "text/plain; charset=utf-8") }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-with-body.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-put-with-content-type-with-body.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-put-with-content-type-with-body
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "put" "http://URL" "body" {} {("content-type", "text/plain; charset=utf-8") }) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-absolute.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-absolute.test
@@ -16,7 +16,7 @@ Location: https://httpbin.org/status/200
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> Dict.remove_v0 "date"
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
       { body = ""
         statusCode = 200
         error = ""

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-200.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-200.test
@@ -15,7 +15,7 @@ Location: /v0/response-redirect-destination
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached"
       statusCode = 200
       error = ""

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-404.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-http-relative-404.test
@@ -17,7 +17,7 @@ Location: /v0/invalid-url
  | Error response ->
     let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
     {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "intentionally not found"
       statusCode = 404
       error = ""

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-to-same-place-relative.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-to-same-place-relative.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-to-same-place-relative
  | Error response ->
     let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
     {response with headers = respHeaders}) =
-  Builtin.HttpClient.Response
+  PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = ""
       statusCode = 302
       error = ""

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-with-auth-header.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-with-auth-header.test
@@ -18,7 +18,7 @@ Location: /v0/response-redirect-dest-with-auth-header
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached with auth"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-with-cookies.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-with-cookies.test
@@ -18,7 +18,7 @@ Location: /v0/response-redirect-dest-with-cookies
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" {} reqHeaders) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached with cookies"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/response-redirect-with-query-params.test
+++ b/backend/testfiles/httpclient/v0/todo/response-redirect-with-query-params.test
@@ -16,7 +16,7 @@ Location: /v0/response-redirect-dest-with-query-params?value=x
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL" { value = "x" } {}) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "Redirect destination reached with params"
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-password.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-password.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://:pa👨‍👩‍👧‍👦ss@URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-username.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-emoji-username.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://us👨‍👩‍👧‍👦er@URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-password.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-password.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://:password@URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username-with-colon.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username-with-colon.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://user:@URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-just-username.test
@@ -19,7 +19,7 @@ Content-Length: LENGTH
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://user@URL" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/todo/uri-with-auth-plus-header.test
+++ b/backend/testfiles/httpclient/v0/todo/uri-with-auth-plus-header.test
@@ -20,7 +20,7 @@ Content-Length: LENGTH
  let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://user:password@URL" {} headers) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { body = "\"Hello back\""
       statusCode = 200
       headers =

--- a/backend/testfiles/httpclient/v0/uri-with-path-basic.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-basic.test
@@ -16,7 +16,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/some/2path/hyphen-ated/under_scored" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers = [
           ("server", "kestrel")

--- a/backend/testfiles/httpclient/v0/uri-with-path-dots.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-dots.test
@@ -16,7 +16,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/some/../2path/hyphen-ated/under_scored/" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/testfiles/httpclient/v0/uri-with-path-slash.test
+++ b/backend/testfiles/httpclient/v0/uri-with-path-slash.test
@@ -16,7 +16,7 @@ Hello back
 (let response = (PACKAGE.Darklang.Stdlib.HttpClient.request "get" "http://URL/" [] Builtin.Bytes.empty) |> Builtin.unwrap
  let respHeaders = response.headers |> PACKAGE.Darklang.Stdlib.List.filter (fun h -> PACKAGE.Darklang.Stdlib.Tuple2.first h != "date")
  {response with headers = respHeaders}) =
-   Builtin.HttpClient.Response
+   PACKAGE.Darklang.Stdlib.HttpClient.Response
     { statusCode = 200
       headers =
         [

--- a/backend/tests/TestUtils/LibTest.fs
+++ b/backend/tests/TestUtils/LibTest.fs
@@ -28,7 +28,6 @@ let modules = [ "Test" ]
 let constant = constant modules
 let fn = fn modules
 
-let types : List<BuiltInType> = []
 let constants : List<BuiltInConstant> =
   [ { name = constant "nan" 0
       typ = TFloat
@@ -325,4 +324,4 @@ let fns : List<BuiltInFn> =
       previewable = Pure
       deprecated = NotDeprecated } ]
 
-let contents = (fns, types, constants)
+let contents = (fns, constants)

--- a/backend/tests/TestUtils/TestUtils.fs
+++ b/backend/tests/TestUtils/TestUtils.fs
@@ -124,7 +124,7 @@ let testDB (name : string) (typ : PT.TypeReference) : PT.DB.T =
 let builtIns
   (httpConfig : BuiltinExecution.Libs.HttpClient.Configuration)
   : RT.BuiltIns =
-  let (fns, types, constants) =
+  let (fns, constants) =
     LibExecution.Builtin.combine
       [ LibTest.contents
         BuiltinExecution.Builtin.contents httpConfig
@@ -132,9 +132,7 @@ let builtIns
         BuiltinDarkInternal.Builtin.contents
         BuiltinCli.Builtin.contents ]
       []
-      []
-  { types = types |> Map.fromListBy (fun typ -> typ.name)
-    fns = fns |> Map.fromListBy (fun fn -> fn.name)
+  { fns = fns |> Map.fromListBy (fun fn -> fn.name)
     constants = constants |> Map.fromListBy (fun c -> c.name) }
 
 let cloudBuiltIns =
@@ -153,7 +151,6 @@ let packageManager = LibCloud.PackageManager.packageManager
 let nameResolver =
   { LibParser.NameResolver.fromBuiltins (
       Map.values localBuiltIns.fns,
-      Map.values localBuiltIns.types,
       Map.values localBuiltIns.constants
     ) with
       packageManager = Some packageManager }

--- a/backend/tests/Tests/Builtin.Tests.fs
+++ b/backend/tests/Tests/Builtin.Tests.fs
@@ -43,29 +43,4 @@ let oldFunctionsAreDeprecated =
       counts
   }
 
-let oldTypesAreDeprecated =
-  testTask "old types are deprecated" {
-    let mutable counts = Map.empty
-
-    let types = localBuiltIns.types |> Map.values
-
-    types
-    |> List.iter (fun typ ->
-      let key = RT.TypeName.builtinToString { typ.name with version = 0 }
-
-      if typ.deprecated = RT.NotDeprecated then
-        counts <-
-          Map.update
-            key
-            (fun count -> count |> Option.defaultValue 0 |> (+) 1 |> Some)
-            counts
-
-      ())
-
-    Map.iter
-      (fun name count ->
-        Expect.equal count 1 $"{name} has more than one undeprecated type")
-      counts
-  }
-
-let tests = testList "builtin" [ oldFunctionsAreDeprecated; oldTypesAreDeprecated ]
+let tests = testList "builtin" [ oldFunctionsAreDeprecated ]

--- a/backend/tests/Tests/Serialization.DarkTypes.Tests.fs
+++ b/backend/tests/Tests/Serialization.DarkTypes.Tests.fs
@@ -30,7 +30,6 @@ module RoundtripTests =
   let types : RT.Types =
     { typeSymbolTable = Map.empty
 
-      builtIn = localBuiltIns.types
       package = packageManager.getType
       userProgram = Map.empty }
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -32,7 +32,6 @@ flowchart LR;
     a4{{raiseRTE a RuntimeError}}
 ```
 
-
 ## Runtime Errors & Type Errors
 
 The primary way of indicating an error in the runtime and during code execution is a
@@ -92,7 +91,6 @@ We're trying to get to a place where we always include a valid `DvalSource` with
 `RuntimeError`, but often it can be hard. We plan to ensure we pass around enough
 information so that `RuntimeError`s always have a `DvalSource`.
 
-
 ### Builtin functions
 
 When writing a builtin function, typically we handle errors by returning a
@@ -102,7 +100,7 @@ appropriate for that function or for general use in the module, defined in a pac
 This sort of error handling is appropriate where the user calls the function
 incorrectly, or something bad happens beyond our control.
 
-Example: `HttpClient.request "mywebsiteisdowntoday.com" = Error HttpClient.ConnectionError`
+Example: `HttpClient.request "mywebsiteisdowntoday.com" = Error HttpClient.NetworkError`
 
 Example: `Float.parse "not a float" = Error Float.Error.InvalidFloatString`
 
@@ -160,8 +158,6 @@ metadata for debugging the issue. We should debug and solve these.
 `Exception.raiseInternal`, in the cli runtime, will hopefully be connected to a wizard
 to allow users to report internal errors semi-automatically for us to debug and solve.
 
-
-
 ## RuntimeError implementation
 
 Unusually, a `RuntimeError` contains a `Dval`, which corresponds to a type in
@@ -197,7 +193,6 @@ Prefer to make a new user-facing `RuntimeError` for your module (or add an extra
 variant to the existing `RuntimeError` enum in a module if there is one and if that
 feels more appropriate).
 
-
 ### What to put in a RuntimeError
 
 `RuntimeError`s often have fields that can be used to provide errors to the user.
@@ -206,4 +201,3 @@ message you'd like the user to see, and to capture any values you need for it. N
 that `RuntimeError`s are raised alongside a `DvalSource` (tlid and id of the
 expression/etc it happens in), so you do not need to capture the Expression being
 executed.
-

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -2,20 +2,29 @@ module Darklang =
   module Stdlib =
     module HttpClient =
 
-      type HeaderError = | EmptyKey
+      type HeaderError =
+        // Occurs whrn a header key is empty. eg. [ ("", "") ]
+        | EmptyKey
 
       type BadUrlDetails =
+        // Occurs when the URI scheme is not allowed. eg. "ftp://darklang.com"
         | UnsupportedProtocol
+        // Occurs when the host is not allowed. eg. "http://0"
         | InvalidHost
+        // Occurs when the URI does not conform to the format specified by RFC 2396. eg. "{ ] nonsense ^#( :"
         | InvalidUri
+        // Occurs when the request contains invalid headers. eg.A request to "http://google.com" with [("Metadata-Flavor", "Google")] header
         | InvalidRequest
 
       type RequestError =
         | BadUrl of BadUrlDetails
+        // Occurs when the request is cancelled due to a timeout
         | Timeout
         | HeaderError of HeaderError
-        | IOError of String
-        | ConnectionError of String
+        // Occurs when an I/O error occurs while making the request
+        | IOError
+        // Occurs when there's an issue connecting to the endpoint. eg. network error, DNS failure, certifivate validation error, etc.
+        | ConnectionError
 
       let toString (e: RequestError) : String =
         match e with
@@ -29,8 +38,8 @@ module Darklang =
         | HeaderError details ->
           match details with
           | EmptyKey -> "Empty key"
-        | IOError details -> $"IOError"
-        | ConnectionError details -> $"Connection error"
+        | IOError -> "IOError"
+        | ConnectionError -> "Connection error"
 
 
       /// The response from a HTTP request

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -13,11 +13,9 @@ module Darklang =
       type RequestError =
         | BadUrl of BadUrlDetails
         | Timeout
-        | NetworkError
         | HeaderError of HeaderError
-        | ArgumentException of String
         | IOException of String
-        | HttpRequestException of String
+        | ConnectionError of String
 
       let toString (e: RequestError) : String =
         match e with
@@ -31,10 +29,8 @@ module Darklang =
         | HeaderError details ->
           match details with
           | EmptyKey -> "Empty key"
-        | ArgumentException details -> $"Argument exception: {details}"
         | IOException details -> $"URI format exception: {details}"
-        | HttpRequestException details -> $"HTTP request exception: {details}"
-        | NetworkError -> "Network error"
+        | ConnectionError details -> $"HTTP request exception: {details}"
 
 
       /// The response from a HTTP request

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -2,6 +2,22 @@ module Darklang =
   module Stdlib =
     module HttpClient =
 
+      type HeaderError =
+        | EmptyKey
+
+      type RequestError =
+        | BadUrl of details : String
+        | Timeout
+        | NetworkError
+        | Other of details : String
+
+      let toString (e: RequestError) : String =
+        match e with
+        | BadUrl details -> $"Bad URL: {details}"
+        | Timeout -> "Timeout"
+        | NetworkError -> "Network error"
+        | Other details -> $"Other error: {details}"
+
       /// The response from a HTTP request
       type Response =
         { statusCode: Int
@@ -17,7 +33,7 @@ module Darklang =
         (uri: String)
         (headers: List<String * String>)
         (body: Bytes)
-        : PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.HttpClient.Response, String> =
+        : PACKAGE.Darklang.Stdlib.Result.Result<PACKAGE.Darklang.Stdlib.HttpClient.Response, PACKAGE.Darklang.Stdlib.HttpClient.RequestError> =
         Builtin.HttpClient.request method uri headers body
 
 

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -14,7 +14,7 @@ module Darklang =
         | BadUrl of BadUrlDetails
         | Timeout
         | HeaderError of HeaderError
-        | IOException of String
+        | IOError of String
         | ConnectionError of String
 
       let toString (e: RequestError) : String =
@@ -29,7 +29,7 @@ module Darklang =
         | HeaderError details ->
           match details with
           | EmptyKey -> "Empty key"
-        | IOException details -> $"URI format exception: {details}"
+        | IOError details -> $"URI format exception: {details}"
         | ConnectionError details -> $"HTTP request exception: {details}"
 
 

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -2,14 +2,13 @@ module Darklang =
   module Stdlib =
     module HttpClient =
 
-      type HeaderError =
-        | EmptyKey
+      type HeaderError = | EmptyKey
 
       type RequestError =
-        | BadUrl of details : String
+        | BadUrl of details: String
         | Timeout
         | NetworkError
-        | Other of details : String
+        | Other of details: String
 
       let toString (e: RequestError) : String =
         match e with

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -29,8 +29,8 @@ module Darklang =
         | HeaderError details ->
           match details with
           | EmptyKey -> "Empty key"
-        | IOError details -> $"URI format exception: {details}"
-        | ConnectionError details -> $"HTTP request exception: {details}"
+        | IOError details -> $"IOError: {details}"
+        | ConnectionError details -> $"Connection error: {details}"
 
 
       /// The response from a HTTP request

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -2,7 +2,7 @@ module Darklang =
   module Stdlib =
     module HttpClient =
 
-      type HeaderError =
+      type BadHeader =
         // Occurs whrn a header key is empty. eg. [ ("", "") ]
         | EmptyKey
 
@@ -20,11 +20,11 @@ module Darklang =
         | BadUrl of BadUrlDetails
         // Occurs when the request is cancelled due to a timeout
         | Timeout
-        | HeaderError of HeaderError
-        // Occurs when an I/O error occurs while making the request
-        | IOError
-        // Occurs when there's an issue connecting to the endpoint. eg. network error, DNS failure, certifivate validation error, etc.
-        | ConnectionError
+        | BadHeader of BadHeader
+        // Occurs when there's an issue connecting to the endpoint or an I/O error. eg. network error, DNS failure, certifivate validation error, etc.
+        | NetworkError
+        // Occurs when the request method is not invalid.
+        | BadMethod
 
       let toString (e: RequestError) : String =
         match e with
@@ -35,11 +35,11 @@ module Darklang =
           | InvalidUri -> "Invalid URI"
           | InvalidRequest -> "Invalid request"
         | Timeout -> "Timeout"
-        | HeaderError details ->
+        | BadHeader details ->
           match details with
           | EmptyKey -> "Empty key"
-        | IOError -> "IOError"
-        | ConnectionError -> "Connection error"
+        | NetworkError -> "NetworkError"
+        | BadMethod -> "BadMethod"
 
 
       /// The response from a HTTP request

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -4,18 +4,38 @@ module Darklang =
 
       type HeaderError = | EmptyKey
 
+      type BadUrlDetails =
+        | UnsupportedProtocol
+        | InvalidHost
+        | InvalidUri
+        | InvalidRequest
+
       type RequestError =
-        | BadUrl of details: String
+        | BadUrl of BadUrlDetails
         | Timeout
         | NetworkError
-        | Other of details: String
+        | HeaderError of HeaderError
+        | ArgumentException of String
+        | IOException of String
+        | HttpRequestException of String
 
       let toString (e: RequestError) : String =
         match e with
-        | BadUrl details -> $"Bad URL: {details}"
+        | BadUrl details ->
+          match details with
+          | UnsupportedProtocol -> "Unsupported protocol"
+          | InvalidHost -> "Invalid host"
+          | InvalidUri -> "Invalid URI"
+          | InvalidRequest -> "Invalid request"
         | Timeout -> "Timeout"
+        | HeaderError details ->
+          match details with
+          | EmptyKey -> "Empty key"
+        | ArgumentException details -> $"Argument exception: {details}"
+        | IOException details -> $"URI format exception: {details}"
+        | HttpRequestException details -> $"HTTP request exception: {details}"
         | NetworkError -> "Network error"
-        | Other details -> $"Other error: {details}"
+
 
       /// The response from a HTTP request
       type Response =

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -29,8 +29,8 @@ module Darklang =
         | HeaderError details ->
           match details with
           | EmptyKey -> "Empty key"
-        | IOError details -> $"IOError: {details}"
-        | ConnectionError details -> $"Connection error: {details}"
+        | IOError details -> $"IOError"
+        | ConnectionError details -> $"Connection error"
 
 
       /// The response from a HTTP request


### PR DESCRIPTION
Most changes here are obvious - just delete stuff. The FQName abstraction is the only real blocker here - see below

First, some misc notes (mostly for my sake, ok to ignore)
- in some places, we were referring to has-been-defunct types still
- Cli builds up an RTE but then... returns it in a normal Error? seems weird

Now for the blocker:
Because of the FQName abstraction, there are some cases where we're trying to map from a [not _really_ allowed, but allowed by type system] Builtin type, and it's unclear how to handle it. Example below from PT2RT:
```fsharp
/* -----PT2RT.fs ----- */

module TypeName =
  module UserProgram =
    let toRT  = ...
    let fromRT  = ...

  module Package =
    let toRT  = ...
    let fromRT = ...

  let toRT (fqtn : PT.TypeName.TypeName) : RT.TypeName.TypeName =
    match fqtn with
    | PT.FQName.BuiltIn _s ->
      RT.raiseString "Not sure what to do here - builtin types are no longer a thing"
    | PT.FQName.UserProgram u -> RT.FQName.UserProgram(UserProgram.toRT u)
    | PT.FQName.Package p -> RT.FQName.Package(Package.toRT p)

  let fromRT (fqtn : RT.TypeName.TypeName) : Option<PT.TypeName.TypeName> =
    match fqtn with
    | RT.FQName.BuiltIn _s ->
      RT.raiseString "Not sure what to do here - builtin types are no longer a thing"
    | RT.FQName.UserProgram u -> PT.FQName.UserProgram(UserProgram.fromRT u) |> Some
    | RT.FQName.Package p -> PT.FQName.Package(Package.fromRT p) |> Some
```

Some options of how to handle this:
- return `None`
- return a (better) RTE
- refactor, and get rid of the FQName abstraction (I actually forget what things looked like before that)

I think `None` works pretty well in this case, but let's also look at ST2PT:
```fsharp
module TypeName =
  module UserProgram =
    let toST = ...
    let toPT = ...

  module Package =
    let toST = ...
    let toPT  = ...

  let toST (fqtn : PT.TypeName.TypeName) : ST.TypeName.TypeName =
    match fqtn with
    | PT.FQName.BuiltIn _s -> LibExecution.RuntimeTypes.raiseString "BuiltIn types not supported"
    | PT.FQName.UserProgram u -> ST.TypeName.UserProgram(UserProgram.toST u)
    | PT.FQName.Package p -> ST.TypeName.Package(Package.toST p)
```

Here, that's not quite an option